### PR TITLE
make standalone python script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ _build/reel_h.quot:        reel.h        _build ;        ./python_quote _REEL_H 
 _build/reel_util_h.quot:   reel_util.h   _build ;   ./python_quote _REEL_UTIL_H $< > $@
 
 
-test: _test _test/reel_compile _test/test.rl _test/trails-bug.tdb.tar build;
+test: _test _test/reel_compile _test/test.rl build;
 
 _test: $(sources) $(headers)
 	$(RM) -rf _test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+.PHONY: all test clean build _build
+
+RM ?= rm -f
+MKDIR ?= mkdir -p
+
+sources := reel_io.c reel_std.c reel_query.c reel_util.c
+headers := reel.h reel_util.h
+scripts := reel_compile reel
+
+quoted := reel_io_c reel_std_c reel_query_c reel_util_c reel_h reel_util_h
+quoted := $(addprefix _build/,$(addsuffix .quot,$(quoted)))
+
+
+all: test
+
+
+build: _build/reel_compile;
+
+_build: $(sources) $(headers) $(scripts)
+	$(RM) -rf _build
+	$(MKDIR) _build
+
+_build/reel_compile: reel_compile $(quoted) _build
+	cp $< $@
+	cat $(quoted) >> $@
+
+_build/reel_io_c.quot:     reel_io.c     _build ;     ./python_quote _REEL_IO_C $< > $@
+
+_build/reel_std_c.quot:    reel_std.c    _build ;    ./python_quote _REEL_STD_C $< > $@
+
+_build/reel_query_c.quot:  reel_query.c  _build ;  ./python_quote _REEL_QUERY_C $< > $@
+
+_build/reel_util_c.quot:   reel_util.c   _build ;   ./python_quote _REEL_UTIL_C $< > $@
+
+_build/reel_h.quot:        reel.h        _build ;        ./python_quote _REEL_H $< > $@
+
+_build/reel_util_h.quot:   reel_util.h   _build ;   ./python_quote _REEL_UTIL_H $< > $@
+
+
+test: _test _test/reel_compile _test/test.rl _test/trails-bug.tdb.tar build;
+
+_test: $(sources) $(headers)
+	$(RM) -rf _test
+	$(MKDIR) _test
+
+_test/reel_compile: _build/reel_compile
+	cp $< $@
+
+_test/test.rl: test.rl
+	cp $< $@
+
+clean:
+	$(RM) -rf ./_build ./_test

--- a/python_quote
+++ b/python_quote
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import sys
+import re
+
+quote_or_backslash = re.compile(r'(["\\])')
+
+(_name, var, path) = sys.argv
+
+with open(path, 'rb') as fh:
+    linum = 1
+    for line in fh:
+        if linum == 1:
+            print var, "=", '"""',
+        # add literal backslash before character
+        print quote_or_backslash.sub(r'\\\1', line),
+        linum += 1
+    print '"""',

--- a/reel
+++ b/reel
@@ -1,13 +1,13 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -euf
 
-if [ -z $1 ]
+if [ -z "$1" ]
 then
     echo "Usage: ./reel reel_script.rl [options] traildb.tdb"
     exit 1
 fi
 
-if [ -z $TRAILDB ]
+if [ -z "$TRAILDB" ]
 then
     echo "Set TRAILDB to point at the root of the TrailDB repo"
     exit 1
@@ -17,18 +17,18 @@ SOURCE=$1
 shift
 
 rm -f reel_query reel_script.c reel_script.h
-./reel_compile $SOURCE
+./reel_compile "$SOURCE"
 gcc -o reel_query\
     -g\
     -O3\
     -Wall\
     -Wno-unused-label\
     -Wno-unused-function\
-    -L $TRAILDB/build\
+    -L "$TRAILDB"/build\
     -I .\
-    -I $TRAILDB/src/\
+    -I "$TRAILDB"/src/\
     reel_query.c reel_util.c reel_script.c\
     -ltraildb\
     -lJudy
 
-LD_LIBRARY_PATH=$TRAILDB/build ./reel_query $@
+LD_LIBRARY_PATH="$TRAILDB"/build ./reel_query "$@"


### PR DESCRIPTION
WIP do not merge

The basic idea make a standalone python executable script that can create an executable for a reelscript / execute a reelscript against a traildb without external dependencies (besides a C compiler).

(I'd just like to take this opportunity to point out that in Perl, we can just use a __DATA__ handle and call it a day).

I want to incorporate libjudy and libtraildb into the python script as well to simplify distribution... Actually, that looks like it's going to be pretty hard and the resulting script will depend on having trialdb and libjudy already available.